### PR TITLE
Chore: add output folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .eggs
 __pycache__
 .snakemake
+alignment


### PR DESCRIPTION
### This PR:

This pull-request adds output folder from the module to gitignore to prevent people from accidentally submitting results file to the repo.

### Review and tests: 
- [x] Tests pass
- [x] Code review
