### PR TITLE
Fix: added type to sample name in BWA

### DIFF
--- a/workflow/rules/bwa_mem.smk
+++ b/workflow/rules/bwa_mem.smk
@@ -15,7 +15,7 @@ rule bwa_mem:
         % (
             config.get("bwa_mem", {}).get("extra", ""),
             config.get("bwa_mem", {}).get(
-                "read_group", "-R '@RG\\tID:{sample}\\tSM:{sample}\\tPL:illumina\\tPU:{sample}' -v 1 "
+                "read_group", "-R '@RG\\tID:{sample}\\tSM:{sample}_{type}\\tPL:illumina\\tPU:{sample}' -v 1 "
             ),
         ),
         sorting=config.get("bwa_mem", {}).get("sort", "samtools"),


### PR DESCRIPTION
Added type to sample name so that mutect2 gets the correct sample name in the vcf file