### PR TITLE
feat: add '-' to barcode wildcard constraint

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -49,7 +49,7 @@ validate(units, schema="../schemas/units.schema.yaml")
 
 
 wildcard_constraints:
-    barcode="[A-Z+]+",
+    barcode="[A-Z+-]+",
     chr="[^_]+",
     flowcell="[A-Z0-9-]+",
     lane="L[0-9]+",


### PR DESCRIPTION
Barcode pairs from a PACBIO uBAM will contain '-'

### This PR:

(If this is a release PR, no need to add following. Leave this part empty)
(Use the following lines to create a PR text body. Make sure to remove all non-relevant one after you're done)
(Repeat each field as many times as necessary)

Added: for new features.
Changed: for changes in existing functionality.
Deprecated: for soon-to-be removed features.
Removed: for now removed features.
Fixed: for any bug fixes.
Security: in case of vulnerabilities.

### Review and tests:
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
- [ ] Module compatibility section in `README.md` is up to date
