### PR TITLE
fix(minimap2): change how the mmi file input path is generated 

### DIFF
--- a/workflow/rules/minimap2.smk
+++ b/workflow/rules/minimap2.smk
@@ -39,7 +39,7 @@ rule minimap2_index:
 rule minimap2_align:
     input:
         query=lambda wildcards: get_minimap2_query(wildcards),
-        target=mmi=expand(
+        target=expand(
             "alignment/minimap2_index/{ref}.{preset}.mmi",
             ref=os.path.basename(config.get("reference", {}).get("fasta", "")),
             preset=config.get("minimap2_align", {}).get("preset", ""),

--- a/workflow/rules/minimap2.smk
+++ b/workflow/rules/minimap2.smk
@@ -39,7 +39,11 @@ rule minimap2_index:
 rule minimap2_align:
     input:
         query=lambda wildcards: get_minimap2_query(wildcards),
-        target=rules.minimap2_index.output.mmi,
+        target=mmi=expand(
+            "alignment/minimap2_index/{ref}.{preset}.mmi",
+            ref=os.path.basename(config.get("reference", {}).get("fasta", "")),
+            preset=config.get("minimap2_align", {}).get("preset", ""),
+        ),
     output:
         bam=temp("alignment/minimap2_align/{sample}_{type}_{processing_unit}_{barcode}.bam"),
     params:

--- a/workflow/rules/pbmm2.smk
+++ b/workflow/rules/pbmm2.smk
@@ -38,7 +38,11 @@ rule pbmm2_index:
 rule pbmm2_align:
     input:
         query=lambda wildcards: get_minimap2_query(wildcards),
-        reference=rules.pbmm2_index.output.mmi,
+        reference=expand(
+            "alignment/pbmm2_index/{ref}.{preset}.mmi",
+            ref=os.path.basename(config.get("reference", {}).get("fasta", "")),
+            preset=config.get("pbmm2_align", {}).get("preset", ""),
+        ),
     output:
         bam=temp("alignment/pbmm2_align/{sample}_{type}_{processing_unit}_{barcode}.bam"),
     params:


### PR DESCRIPTION
### This PR:

The previous use of rules.minimap2_index.output.mmi and rules.pbmm2_index.output.mmi could cause a WorkflowError when only a subset of rules were included from the module in a pipeline. This create the path to the mmi files using the same methods as the output for the minimap2_index and pbmm2_index rules.

(If this is a release PR, no need to add following. Leave this part empty)
(Use the following lines to create a PR text body. Make sure to remove all non-relevant one after you're done)
(Repeat each field as many times as necessary)

Added: for new features.
Changed: for changes in existing functionality.
Deprecated: for soon-to-be removed features.
Removed: for now removed features.
Fixed: for any bug fixes.
Security: in case of vulnerabilities.

### Review and tests:
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
- [ ] Module compatibility section in `README.md` is up to date
