### PR TITLE
fix: update samtools merge wrapper version

### DIFF
--- a/workflow/rules/bwa.smk
+++ b/workflow/rules/bwa.smk
@@ -81,7 +81,7 @@ rule bwa_mem_merge:
     message:
         "{rule}: merge bam file {input} using samtools"
     wrapper:
-        "v1.1.0/bio/samtools/merge"
+        "v9.4.1/bio/samtools/merge"
 
 
 rule bwa_mem_realign_consensus_reads:

--- a/workflow/rules/minimap2.smk
+++ b/workflow/rules/minimap2.smk
@@ -106,4 +106,4 @@ rule minimap2_merge:
     message:
         "{rule}: merge {input.bams} using samtools merge"
     wrapper:
-        "v3.9.0/bio/samtools/merge"
+        "v9.4.1/bio/samtools/merge"

--- a/workflow/rules/pbmm2.smk
+++ b/workflow/rules/pbmm2.smk
@@ -101,4 +101,4 @@ rule pbmm2_merge:
     message:
         "{rule}: merge bam file {input} using samtools"
     wrapper:
-        "v3.9.0/bio/samtools/merge"
+        "v9.4.1/bio/samtools/merge"

--- a/workflow/rules/samtools.smk
+++ b/workflow/rules/samtools.smk
@@ -190,7 +190,7 @@ rule samtools_merge_bam:
     message:
         "{rule}: merge chr bam files, creating {output}"
     wrapper:
-        "v1.1.0/bio/samtools/merge"
+        "v9.4.1/bio/samtools/merge"
 
 
 rule samtools_sort:

--- a/workflow/rules/vacmap.smk
+++ b/workflow/rules/vacmap.smk
@@ -65,4 +65,4 @@ rule vacmap_merge:
     message:
         "{rule}: merge {input.bams} using samtools merge"
     wrapper:
-        "v3.9.0/bio/samtools/merge"
+        "v9.4.1/bio/samtools/merge"


### PR DESCRIPTION
### This PR:

Previous version 3.9.0 could not be found and downloaded

Fixed: bump samtools merge wrapper version

### Review and tests:
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
- [ ] Module compatibility section in `README.md` is up to date


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded samtools merge tool to version 9.4.1 across all workflow analysis components. This update standardizes tool versions previously scattered across multiple releases (v1.1.0 and v3.9.0), ensuring consistent behavior and improved compatibility throughout the pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->