### PR TITLE
feat: use -c -p in  default extra params for samtools merge

### DIFF
--- a/workflow/rules/samtools.smk
+++ b/workflow/rules/samtools.smk
@@ -170,7 +170,7 @@ rule samtools_merge_bam:
     output:
         bam=temp("alignment/samtools_merge_bam/{sample}_{type}_unsorted.bam"),
     params:
-        extra=config.get("samtools_merge_bam", {}).get("extra", ""),
+        extra=config.get("samtools_merge_bam", {}).get("extra", "-c -p"),
     log:
         "alignment/samtools_merge_bam/{sample}_{type}_unsorted.bam.log",
     benchmark:


### PR DESCRIPTION
### This PR:
Added the -c and -p args as defaults to samtools merge bam. The -c and -p args are sensible defaults if one wants merge bam files after picard markduplicates. It will also remove unnecessary differences when comparing bam files between different versions of pipelines:

These parameters are explained at http://www.htslib.org/doc/samtools-merge.html:

-c
When several input files contain @RG headers with the same ID, emit only one of them (namely, the header line from the first file we find that ID in) to the merged output file. Combining these similar headers is usually the right thing to do when the files being merged originated from the same file.

Without -c, all @RG headers appear in the output file, with random suffixes added to their IDs where necessary to differentiate them.

-p
Similarly, for each @PG ID in the set of files to merge, use the @PG line of the first file we find that ID in rather than adding a suffix to differentiate similar IDs.

### Review and tests:
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
- [ ] Module compatibility section in `README.md` is up to date


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Modified default BAM file merging behavior to enable compression and parallel processing options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hydra-genetics/alignment/pull/181)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->